### PR TITLE
Enable a patch by Lucas only when using non-Cygwin LaTeX from Cygwin

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -760,6 +760,11 @@ else
 	esac
     fi
 fi
+## A function to check if using non-Cygwin "${latex}" from Cygwin
+using_non_cygwin_latex_from_cygwin () {
+  [ x"$(uname -o)" = x"Cygwin" ] \
+  && "${latex}" -version | head -1 | grep -qv Cygwin
+}
 ##
 ##  END OF CHECKING THE SETUP
 ##
@@ -809,9 +814,9 @@ else
 fi
 umask "$original_umask"
 ## Next is from the Cygwin patch contributed by Lucas
-case $(uname) in
-    *CYGWIN*) PDFJAM_TEMP_DIR=$(cygpath -w "$PDFJAM_TEMP_DIR");;
-esac
+if using_non_cygwin_latex_from_cygwin; then
+    PDFJAM_TEMP_DIR=$(cygpath -w "$PDFJAM_TEMP_DIR")
+fi
 ##
 ##  TEMPORARY DIRECTORY ALL DONE
 ##
@@ -937,10 +942,11 @@ do
 	    uniqueName="source-$counter.pdf"
 	    uniqueName="$PDFJAM_TEMP_DIR"/"$uniqueName"
 	    ## Next is from the Cygwin patch contributed by Lucas
-	    case $(uname) in
-		*CYGWIN*) cp "$sourceFullPath" "$uniqueName";;
-		*) ln -s "$sourceFullPath" "$uniqueName";;
-            esac
+	    if using_non_cygwin_latex_from_cygwin; then
+		cp "$sourceFullPath" "$uniqueName"
+	    else
+		ln -s "$sourceFullPath" "$uniqueName"
+	    fi
 	    ;;
     esac
     filePageList="$filePageList","$uniqueName","$pageSpec"
@@ -991,9 +997,9 @@ texFile="$fileName".tex
 msgFile="$fileName".msgs
 tempFile="$PDFJAM_TEMP_DIR"/temp.tex
 ## Next is adapted from the Cygwin patch sent by Lucas
-case $(uname) in
-    *CYGWIN*) filePageList=$(echo "$filePageList" | sed 's~\\~/~g') ;;
-esac
+if using_non_cygwin_latex_from_cygwin; then
+    filePageList=$(echo "$filePageList" | sed 's~\\~/~g')
+fi
 (cat <<EndTemplate
 \batchmode
 \documentclass[$documentOptions]{article}

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -664,7 +664,7 @@ documentOptions=$(printf "%s" "$documentOptions" | sed 's/^,//' | sed 's/,$//')
 if test $PDFJAM_CALL_NUMBER -eq 0  ## not a secondary call
 then
     ##  Check whether there's a suitable latex to use:
-    case $latex in
+    case "$latex" in
 	"not found")
 	    error_exit "can't find pdflatex!" $E_UNAVAILABLE
 	    ;;
@@ -735,7 +735,7 @@ then
 else
     if  test "$keepinfo" = true
     then
-	case $pdfinfo in
+	case "$pdfinfo" in
 	    "not found")
 		if test $PDFJAM_CALL_NUMBER -eq 0
 		then
@@ -1059,7 +1059,7 @@ log file at
 to try to diagnose the problem."
 i=1
 while [ "$i" -le "$runs" ] ; do
-    $latex "$texFile" > "$msgFile" || {
+    "$latex" "$texFile" > "$msgFile" || {
         prattle "$failureText"
         error_exit "Run $i: Output file not written" $E_SOFTWARE
     }

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -762,8 +762,15 @@ else
 fi
 ## A function to check if using non-Cygwin "${latex}" from Cygwin
 using_non_cygwin_latex_from_cygwin () {
-  [ x"$(uname -o)" = x"Cygwin" ] \
-  && "${latex}" -version | head -1 | grep -qv Cygwin
+    if [ -z "${__cache__using_non_cygwin_latex_from_cygwin}" ]; then
+	if [ x"$(uname -o)" = x"Cygwin" ] \
+	    && "${latex}" -version | head -1 | grep -qv Cygwin; then
+	    __cache__using_non_cygwin_latex_from_cygwin=0
+	else
+	    __cache__using_non_cygwin_latex_from_cygwin=1
+	fi
+    fi
+    return "${__cache__using_non_cygwin_latex_from_cygwin}"
 }
 ##
 ##  END OF CHECKING THE SETUP


### PR DESCRIPTION
This is another candidate to fix failure on cygwin #20, keeping Lucas' patch #3 (72d12db07a49f9098e470fc770fe3f6e5036b9d5) effective only when using non-Cygwin LaTeX from a Cygwin environment.