### PR TITLE
Improve pipelines on cygwin (and possibly on other systems)

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -1110,7 +1110,10 @@ then
     error_exit "no write permission at ${outFile}" $E_CANTCREATE
 fi
 #fileSize=$(wc -c < "$fileName.pdf" | sed 's/^\ *//')
-if cat "$fileName".pdf > "$outFile" 2>/dev/null
+## Avoid explicit output to /dev/stdout.
+if test x"$outFile" = x"/dev/stdout" \
+   && cat "$fileName".pdf 2> /dev/null \
+   || cat "$fileName".pdf > "$outFile" 2>/dev/null
 then
     prattle "Finished.  Output was written to '${outFile}'."
 else


### PR DESCRIPTION
This PR includes #22, because it is related to Cygwin.
The commit d4025732b0fca36950ae9de60b9bd256da0b7617 might improve pipelines on Cygwin.

The issue has been pointed out in `README.md`:
````
- In _Cygwin_, using `pdfjam` in a pipeline does not seem to work. 
  The problem seems to be with _Cygwin_'s handling of file descriptors 
  within pipelines.
````