### PR TITLE
Disable latex package check for tectonic tex engine

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -681,17 +681,19 @@ then
 	PATH="$modifyPath:$PATH"
 	export PATH
     fi
-    (kpsewhich pdfpages.sty >/dev/null) ||
-    error_exit \
-	"LaTeX package pdfpages.sty is not installed" \
-	$E_UNAVAILABLE
-
-    for pack in geometry pdflscape eso-pic everyshi atbegshi ; do
-        (kpsewhich $pack.sty >/dev/null) ||
-        error_exit \
-	    "LaTeX package $pack.sty is not installed (see the pdfpages manual)" \
+    if [[ "$latex" != *"tectonic"* ]]; then
+    	(kpsewhich pdfpages.sty >/dev/null) ||
+    	error_exit \
+	    "LaTeX package pdfpages.sty is not installed" \
 	    $E_UNAVAILABLE
-    done
+
+    	for pack in geometry pdflscape eso-pic everyshi atbegshi ; do
+	    (kpsewhich $pack.sty >/dev/null) ||
+            error_exit \
+	        "LaTeX package $pack.sty is not installed (see the pdfpages manual)" \
+	        $E_UNAVAILABLE
+	done
+    fi
 fi
 if  test "$keepinfo" = true
 then

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -681,7 +681,7 @@ then
 	PATH="$modifyPath:$PATH"
 	export PATH
     fi
-    if [[ "$latex" != *"tectonic"* ]]; then
+    if "$latex" != -- *"tectonic"*; then
     	(kpsewhich pdfpages.sty >/dev/null) ||
     	error_exit \
 	    "LaTeX package pdfpages.sty is not installed" \


### PR DESCRIPTION
Adding support for [tectonic](https://tectonic-typesetting.github.io/en-US/) tex engine, this engine automatically downloads the needed latex packages on the go (hence the packages would be downloaded after this check is performed), so this check would fail and therefore this check is not required for tectonic.