### PR TITLE
Use the standard IANA character encoding names

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -951,7 +951,7 @@ select_pdfinfo () {
 }
 echo_hex_iconv_utf16be () {
     printf '%s' "$1" | \
-    "$iconv" -f utf8 -t utf16be | \
+    "$iconv" -f UTF-8 -t UTF-16BE | \
     od -An -v -tx1 | \
     tr -d '[:space:]'
 }
@@ -972,7 +972,7 @@ if test "$keepinfo" = true ; then
 fi
 echo_iconv_from_enc () {
     printf '%s' "$2" | \
-    "$iconv" -f "$1" -t utf8
+    "$iconv" -f "$1" -t UTF-8
 }
 if test -n "$pdfTitle" ; then
     pdftitl=$(echo_iconv_from_enc "$enc" "$pdfTitle")

--- a/pdfjam.conf
+++ b/pdfjam.conf
@@ -100,7 +100,7 @@ twoside='false'     ## overridden by '--twoside' in the call
 ##
 preamble=''         ## concatenate other strings to this by using '--preamble'
 ##
-# enc='utf8'        ## overridden by '--enc ENC' in the call
+# enc='UTF-8'       ## overridden by '--enc ENC' in the call
 #                   ## ENC must be one of iconv encodings
 ##
 ###############################################################


### PR DESCRIPTION
https://www.iana.org/assignments/character-sets/character-sets.xhtml

This solves the problem of pdfjam failing when used with GNU libiconv, which works with the standard names ("UTF-8" and "UTF-16BE"), but not alternative names (such as "utf8" and "utf16be").

https://lists.gnu.org/archive/html/bug-gnu-libiconv/2019-01/msg00001.html