### PR TITLE
Fix typo 'connected to'

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -942,7 +942,7 @@ do
 	    then
 		if tty -s ; then
 		    error_exit \
-		 "tty is connected to connected to stdin, no PDF/JPG/PNG file found" \
+		 "tty is connected to stdin, no PDF/JPG/PNG file found" \
 			$E_NOINPUT
 		fi
 		cat > "$uniqueName"


### PR DESCRIPTION
There is a repeated sentence.
<img width="650" alt="image" src="https://github.com/rrthomas/pdfjam/assets/24670874/617610ed-cd62-44fd-a1e8-9e01b4259719">
